### PR TITLE
upgrade dependancy and remove mocha as promise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.8"
+  - "4"
+  - "5"

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ $(BIN)/%:
 
 test: $(BIN)/mocha index.js
 	$(BIN)/mocha \
-	  --compilers coffee:coffee-script \
+	  --compilers coffee:coffee-script/register \
 	  --reporter spec test.coffee \
 	  --slow 1000
 

--- a/package.json
+++ b/package.json
@@ -8,14 +8,13 @@
   "license": "MIT",
   "scripts": { "test": "make test" },
   "dependencies": {
-    "throat": "~1.0.0",
-    "q": "~1.0.0"
+    "throat": "~2.0.2",
+    "q": "~1.4.1"
   },
   "devDependencies": {
-    "coffee-script": "~1.6.3",
-    "chai": "~1.8.1",
-    "chai-as-promised": "~4.1.0",
-    "mocha-as-promised": "~2.0.0",
-    "mocha": "~1.16.2"
+    "coffee-script": "~1.10.0",
+    "chai": "~3.4.1",
+    "chai-as-promised": "~5.2.0",
+    "mocha": "~2.3.4"
   }
 }

--- a/test.coffee
+++ b/test.coffee
@@ -1,7 +1,7 @@
 async = require './'
 Q     = require 'q'
 
-require('mocha-as-promised')()
+require('mocha')
 chai = require 'chai'
 chai.use require 'chai-as-promised'
 { assert: { strictEqual: equal, deepEqual, isRejected, fail, becomes, ok }


### PR DESCRIPTION
* upgrade all dependency in package.json
* upgrade node version in .travis.yml
* remove mocha as promise package because, promises has been included in latest version of mocha,
* add /registry to Makefile as mocha to run with upgraded versions

above all passes all of the test cases on node version 4 and 5

