### PR TITLE
support promises in object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /index.js
 /node_modules
 .*.swp

--- a/README.md
+++ b/README.md
@@ -588,8 +588,8 @@ all.
 
 __Arguments__
 
-* tasks - An array or object containing functions to run, each function
-  should return a promise for an optional value.
+* tasks - An array, object containing functions to run (each function
+  should return a promise for an optional value), or an object containing promises that resolve a value
 
 __Example__
 
@@ -603,7 +603,7 @@ async.parallel([
     doStuff()
   .done()
 
-### an example using an object instead of an array ###
+### an example using an object of functions instead of an array ###
 async.parallel({
   one: -> Q.delay(200).thenResolve(1)
   two: -> Q.delay(100).thenResolve(2)
@@ -611,6 +611,15 @@ async.parallel({
     ### results is now equals to: {one: 1, two: 2} ###
     doStuff()
   .done()
+  
+### an example using an object of promises instead of an array ###
+async.parallel({
+one: Q.delay(200).thenResolve(1)
+two: Q.delay(100).thenResolve(2)
+}).then (results) ->
+  ### results is now equals to: {one: 1, two: 2} ###
+  doStuff()
+.done()
 ```
 
 ---------------------------------------

--- a/async.coffee
+++ b/async.coffee
@@ -141,7 +141,11 @@ module.exports = async =
       ).then(-> results)
 
   parallel: Q.promised (tasks) ->
-    processArrayOrObject tasks, (arr) -> Q.all arr.map Q.try
+    processArrayOrObject tasks, (arr) -> Q.all arr.map (task) ->
+      if task.then
+       task
+      else
+        Q.try task
 
   parallelLimit: Q.promised (tasks, limit) ->
     processArrayOrObject tasks, (arr) ->

--- a/test.coffee
+++ b/test.coffee
@@ -265,6 +265,15 @@ describe 'parallel()', ->
       /^error1$/
     )
 
+  it 'accepts an object of promises', ->
+    obj =
+      one: Q.delay(125).thenResolve 1
+      two: Q.delay(200).thenResolve 2
+      three: Q.delay(50).thenResolve [3,3]
+
+    async.parallel(obj).then (results) ->
+      deepEqual results, one: 1, two: 2, three: [3, 3]
+
   it 'accepts an object', ->
     call_order = []
     async.parallel(getFunctionsObject call_order).then (results) ->


### PR DESCRIPTION
Allows you to send existing promises directly into the parallel call vs. wrapping in a function
